### PR TITLE
app.js

### DIFF
--- a/JS/Simon Says/app.js
+++ b/JS/Simon Says/app.js
@@ -36,7 +36,7 @@ function levelUp() {
   level++;
   h2.innerText = `Level ${level}`;
 
-  let randIdx = Math.floor(Math.random() * 3);
+  let randIdx = Math.floor(Math.random() * 4);
   let randColor = btns[randIdx];
   let randBtn = document.querySelector(`.${randColor}`);
   gameSeq.push(randColor);


### PR DESCRIPTION
Math.floor(Math.random * 4) 

it is because length of the  array is 4 and by taking 3 we will miss one colour tile every time and will never be the randomly selected tile.